### PR TITLE
RegisterAndStart changes

### DIFF
--- a/kdmapper/service.cpp
+++ b/kdmapper/service.cpp
@@ -52,6 +52,11 @@ bool service::RegisterAndStart(const std::wstring& driver_path) {
 	Status = NtLoadDriver(&serviceStr);
 	Log("[+] NtLoadDriver Status 0x" << std::hex << Status << std::endl);
 
+    if (Status == 0xC000010E) // ntstatus.h STATUS_IMAGE_ALREADY_LOADED = 0xC000010E
+	{
+		return true;
+	}
+	
 	return NT_SUCCESS(Status);
 }
 

--- a/kdmapper/service.cpp
+++ b/kdmapper/service.cpp
@@ -51,9 +51,9 @@ bool service::RegisterAndStart(const std::wstring& driver_path) {
 
 	Status = NtLoadDriver(&serviceStr);
 	Log("[+] NtLoadDriver Status 0x" << std::hex << Status << std::endl);
-
-    if (Status == 0xC000010E) // ntstatus.h STATUS_IMAGE_ALREADY_LOADED = 0xC000010E
-	{
+	
+	//Never should occur since kdmapper checks for "IsRunning" driver before
+	if (Status == 0xC000010E) {// STATUS_IMAGE_ALREADY_LOADED
 		return true;
 	}
 	


### PR DESCRIPTION
In RegisterAndStart, modified to return true if status equals 0xC000010E (STATUS_IMAGE_ALREADY_LOADED in ntstatus.h), should be a self-explanatory fix.