### PR TITLE
22621.819 Update

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ Updated and improved by https://github.com/TheCruZ
 
 Mdl allocation writed by https://github.com/TygoL
 
-Tested from **Windows 10 1607** to current **Windows 11 22449.1** :heavy_check_mark:
+Tested from **Windows 10 1607** to **Windows 11 22449.1** :heavy_check_mark:
 
 Update mainly done for UnknownCheats Forum https://www.unknowncheats.me/forum/members/1117395.html
 
@@ -37,5 +37,8 @@ KDMapper is a simple tool that exploits iqvw64e.sys Intel driver to manually map
 
 ### Errors 0xC0000022 and 0xC000009A:
 A lot of people ask me about this errors loading the vulnerable driver, both are caused by FACEIT AC since his driver is always running you have to uninstall it
+
+### Error 0xC0000603:
+On versions after Windows 11 22H2 (22621.819), the certificate for the  has been revoked and the mapper will return a status of STATUS_IMAGE_CERT_REVOKED.
 
 Have Fun!!


### PR DESCRIPTION
After 22621.819, it will return 0xC0000603 even with Core Isolation and  `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\CI\Config\VulnrableDriverBlocklistEnable` disabled.