### PR TITLE
Security Cookie Fix

### DIFF
--- a/HelloWorld/HelloWorld.vcxproj
+++ b/HelloWorld/HelloWorld.vcxproj
@@ -35,6 +35,7 @@
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -87,7 +88,8 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <Link>
-      <EntryPointSymbol>CustomDriverEntry</EntryPointSymbol>
+      <EntryPointSymbol>
+      </EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/HelloWorld/main.cpp
+++ b/HelloWorld/main.cpp
@@ -1,7 +1,7 @@
 
 #include <ntddk.h>
 
-NTSTATUS CustomDriverEntry(
+NTSTATUS NtProcessStartup(
 	_In_ PDRIVER_OBJECT  kdmapperParam1,
 	_In_ PUNICODE_STRING kdmapperParam2
 )

--- a/kdmapper/kdmapper.hpp
+++ b/kdmapper/kdmapper.hpp
@@ -20,6 +20,7 @@ namespace kdmapper
 	//Note: if you set PassAllocationAddressAsFirstParam as true, param1 will be ignored
 	uint64_t MapDriver(HANDLE iqvw64e_device_handle, BYTE* data, ULONG64 param1 = 0, ULONG64 param2 = 0, bool free = false, bool destroyHeader = true, bool mdlMode = false, bool PassAllocationAddressAsFirstParam = false, mapCallback callback = nullptr, NTSTATUS* exitCode = nullptr);
 	void RelocateImageByDelta(portable_executable::vec_relocs relocs, const uint64_t delta);
+	bool FixSecurityCookie(void* local_image);
 	bool ResolveImports(HANDLE iqvw64e_device_handle, portable_executable::vec_imports imports);
 	uint64_t AllocMdlMemory(HANDLE iqvw64e_device_handle, uint64_t size, uint64_t* mdlPtr);
 }

--- a/kdmapper/kdmapper.vcxproj
+++ b/kdmapper/kdmapper.vcxproj
@@ -20,14 +20,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>


### PR DESCRIPTION
Add the possibility to use non custom entry point (NtProcessStartup) and so the crt (which is useless) but nice, it also can't really fail