### PR TITLE
Add allocation mode with MmAllocateIndependentPagesEx

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,8 @@ Updated and improved by https://github.com/TheCruZ
 
 Mdl allocation writed by https://github.com/TygoL
 
+Independent Pages allocation written by https://github.com/Herooyyy/
+
 Tested from **Windows 10 1607** to **Windows 11 22449.1** :heavy_check_mark:
 
 Update mainly done for UnknownCheats Forum https://www.unknowncheats.me/forum/members/1117395.html
@@ -26,6 +28,7 @@ KDMapper is a simple tool that exploits iqvw64e.sys Intel driver to manually map
 	Header section skipped while copying driver to kernel
 	Added param --free to automatically unmap the allocated memory
 	Added param --mdl to map in mdl memory
+	Added param --indPages to map in allocated independent pages
 	Added param --PassAllocationPtr to pass allocation ptr as first param
 	Added the possibility to modify params before call driver entry
 	Now you can pass directly bytes to mapdriver function

--- a/kdmapper/intel_driver.hpp
+++ b/kdmapper/intel_driver.hpp
@@ -130,6 +130,11 @@ namespace intel_driver
 	bool ReadMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size);
 	bool WriteMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size);
 	bool WriteToReadOnlyMemory(HANDLE device_handle, uint64_t address, void* buffer, uint32_t size);
+	/*added by herooyyy*/
+	uint64_t MmAllocateIndependentPagesEx(HANDLE device_handle, uint32_t size);
+	void MmFreeIndependentPages(HANDLE device_handle, uint64_t address, uint32_t size);
+	BOOLEAN MmSetPageProtection(HANDLE device_handle, uint64_t address, uint32_t size, ULONG new_protect);
+	
 	uint64_t AllocatePool(HANDLE device_handle, nt::POOL_TYPE pool_type, uint64_t size);
 	/*added by psec*/
 	uint64_t MmAllocatePagesForMdl(HANDLE device_handle, LARGE_INTEGER LowAddress, LARGE_INTEGER HighAddress, LARGE_INTEGER SkipBytes, SIZE_T TotalBytes);

--- a/kdmapper/kdmapper.hpp
+++ b/kdmapper/kdmapper.hpp
@@ -18,8 +18,9 @@ namespace kdmapper
 	typedef bool (*mapCallback)(ULONG64* param1, ULONG64* param2, ULONG64 allocationPtr, ULONG64 allocationSize, ULONG64 mdlptr);
 
 	//Note: if you set PassAllocationAddressAsFirstParam as true, param1 will be ignored
-	uint64_t MapDriver(HANDLE iqvw64e_device_handle, BYTE* data, ULONG64 param1 = 0, ULONG64 param2 = 0, bool free = false, bool destroyHeader = true, bool mdlMode = false, bool PassAllocationAddressAsFirstParam = false, mapCallback callback = nullptr, NTSTATUS* exitCode = nullptr);
+	uint64_t MapDriver(HANDLE iqvw64e_device_handle, BYTE* data, ULONG64 param1 = 0, ULONG64 param2 = 0, bool free = false, bool destroyHeader = true, bool mdlMode = false, bool indPagesMode = false, bool PassAllocationAddressAsFirstParam = false, mapCallback callback = nullptr, NTSTATUS* exitCode = nullptr);
 	void RelocateImageByDelta(portable_executable::vec_relocs relocs, const uint64_t delta);
 	bool ResolveImports(HANDLE iqvw64e_device_handle, portable_executable::vec_imports imports);
+	uint64_t AllocIndependentPages(HANDLE device_handle, uint32_t size);
 	uint64_t AllocMdlMemory(HANDLE iqvw64e_device_handle, uint64_t size, uint64_t* mdlPtr);
 }

--- a/kdmapper/main.cpp
+++ b/kdmapper/main.cpp
@@ -55,6 +55,7 @@ int wmain(const int argc, wchar_t** argv) {
 
 	bool free = paramExists(argc, argv, L"free") > 0;
 	bool mdlMode = paramExists(argc, argv, L"mdl") > 0;
+	bool indPagesMode = paramExists(argc, argv, L"indPages") > 0;
 	bool passAllocationPtr = paramExists(argc, argv, L"PassAllocationPtr") > 0;
 
 	if (free) {
@@ -63,6 +64,10 @@ int wmain(const int argc, wchar_t** argv) {
 
 	if (mdlMode) {
 		Log(L"[+] Mdl memory usage enabled" << std::endl);
+	}
+
+	if (indPagesMode) {
+		Log(L"[+] Allocate Independent Pages mode enabled" << std::endl);
 	}
 
 	if (passAllocationPtr) {
@@ -102,7 +107,7 @@ int wmain(const int argc, wchar_t** argv) {
 	}
 
 	NTSTATUS exitCode = 0;
-	if (!kdmapper::MapDriver(iqvw64e_device_handle, raw_image.data(), 0, 0, free, true, mdlMode, passAllocationPtr, callbackExample, &exitCode)) {
+	if (!kdmapper::MapDriver(iqvw64e_device_handle, raw_image.data(), 0, 0, free, true, mdlMode, indPagesMode, passAllocationPtr, callbackExample, &exitCode)) {
 		Log(L"[-] Failed to map " << driver_path << std::endl);
 		intel_driver::Unload(iqvw64e_device_handle);
 		return -1;


### PR DESCRIPTION
Tested only on windows 10 22h2 (Build 19045.2728)

Don't have other VM's at hand with other windows versions. Things that could break are the 3 signatures that I used.

MmAllocateIndependentPagexEx:
\x48\x8B\xC4\x48\x89\x58\x10\x44\x89\x48\x20\x55\x56\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x81\xEC\x00\x00\x00\x00
xxxxxxxxxxxxxxxxxxxxxxxxx????

MmFreeIndependentPages
\x48\x89\x5C\x24\x00\x55\x56\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x8B\xEC\x48\x83\xEC\x60\x48\x83\x65\x00\x00\xBE\x00\x00\x00\x00\x48\x83\x65\x00\x00
xxxx?xxxxxxxxxxxxxxxxxxxxx??x????xxx??

MmSetPageProtection
\x48\x89\x5C\x24\x00\x55\x56\x57\x41\x56\x41\x57\x48\x81\xEC\x00\x00\x00\x00\x48\x8B\x05\x00\x00\x00\x00\x48\x33\xC4\x48\x89\x84\x24\x00\x00\x00\x00\x41\x8B\xD8\x4C\x8B\xFA
xxxx?xxxxxxxxxx????xxx????xxxxxxx????xxxxxx