### PR TITLE
Update KDSymbolsHandler.cpp

### DIFF
--- a/kdmapper/KDSymbolsHandler.cpp
+++ b/kdmapper/KDSymbolsHandler.cpp
@@ -23,8 +23,8 @@ bool KDSymbolsHandler::ReloadFile(std::wstring path, std::wstring updater) {
 		//delete old file
 		std::filesystem::remove(path);
 
-		std::string cmd = "\"" + std::string(updater.begin(), updater.end()) + "\"";
-		auto exitCode = system(cmd.c_str());
+		std::wstring cmdW = L"\"" + updater + L"\"";
+		auto exitCode = _wsystem(cmdW.c_str());
 		if (exitCode != 0) {
 			std::wcout << L"[-] Failed to update offsets" << std::endl;
 			return false;


### PR DESCRIPTION
- Changed variable 'std::string cmd' -> 'std::wstring cmdW'.
- Changed function call 'system()' -> '_wsystem()'. This allows to use spaces and non-ASCII symbols in .exe path