### PR TITLE
Runtime driver timestamp

### DIFF
--- a/kdmapper/include/intel_driver.hpp
+++ b/kdmapper/include/intel_driver.hpp
@@ -10,9 +10,7 @@
 namespace intel_driver
 {
 	constexpr ULONG32 ioctl1 = 0x80862007;
-	constexpr DWORD iqvw64e_timestamp = 0x5284EAC3;
 	extern ULONG64 ntoskrnlAddr;
-
 
 	bool ClearPiDDBCacheTable(HANDLE device_handle);
 	bool ExAcquireResourceExclusiveLite(HANDLE device_handle, PVOID Resource, BOOLEAN wait);

--- a/kdmapper/intel_driver.cpp
+++ b/kdmapper/intel_driver.cpp
@@ -7,6 +7,7 @@
 #include "intel_driver_resource.hpp"
 #include "service.hpp"
 #include "nt.hpp"
+#include "portable_executable.hpp"
 
 #ifdef PDB_OFFSETS
 #include "KDSymbolsHandler.h"
@@ -992,8 +993,10 @@ bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTabl
 
 	auto n = GetDriverNameW();
 
+	auto timestamp = portable_executable::GetNtHeaders((void*)intel_driver_resource::driver)->FileHeader.TimeDateStamp;
+
 	// search our entry in the table
-	nt::PiDDBCacheEntry* pFoundEntry = (nt::PiDDBCacheEntry*)LookupEntry(device_handle, PiDDBCacheTable, iqvw64e_timestamp, n.c_str());
+	nt::PiDDBCacheEntry* pFoundEntry = (nt::PiDDBCacheEntry*)LookupEntry(device_handle, PiDDBCacheTable, timestamp, n.c_str());
 	if (pFoundEntry == nullptr) {
 		Log(L"[-] Not found in cache" << std::endl);
 		ExReleaseResourceLite(device_handle, PiDDBLock);


### PR DESCRIPTION
Replaced hardcoded iqvw64e_timestamp with a runtime timestamp retrieved from the vulnerable driver's NT headers to avoid manual updates when the driver binary changes.