### PR TITLE
Refactor status code handling to use NTSTATUS constants

### DIFF
--- a/kdmapper/include/nt.hpp
+++ b/kdmapper/include/nt.hpp
@@ -1,12 +1,15 @@
-#pragma once
+﻿#pragma once
 #include <Windows.h>
 #include <winternl.h>
 #pragma comment(lib, "ntdll.lib")
 
+#pragma warning(push)
+#pragma warning(disable: 4005) //macro redefinition
+#include <ntstatus.h>
+#pragma warning(pop)
+
 namespace nt
 {
-	constexpr auto STATUS_INFO_LENGTH_MISMATCH = 0xC0000004;
-
 	constexpr auto SystemModuleInformation = 11;
 	constexpr auto SystemExtendedHandleInformation = 64;
 

--- a/kdmapper/intel_driver.cpp
+++ b/kdmapper/intel_driver.cpp
@@ -751,7 +751,7 @@ bool intel_driver::ClearMmUnloadedDrivers(HANDLE device_handle) {
 
 	NTSTATUS status = NtQuerySystemInformation(static_cast<SYSTEM_INFORMATION_CLASS>(nt::SystemExtendedHandleInformation), buffer, buffer_size, &buffer_size);
 
-	while (status == nt::STATUS_INFO_LENGTH_MISMATCH)
+	while (status == STATUS_INFO_LENGTH_MISMATCH)
 	{
 		VirtualFree(buffer, 0, MEM_RELEASE);
 

--- a/kdmapper/service.cpp
+++ b/kdmapper/service.cpp
@@ -56,21 +56,19 @@ bool service::RegisterAndStart(const std::wstring& driver_path, const std::wstri
 
 	Status = nt::NtLoadDriver(&serviceStr);
 
-
 	Log("[+] NtLoadDriver Status 0x" << std::hex << Status << std::endl);
 
-	if (Status == 0xC0000603) { //STATUS_IMAGE_CERT_REVOKED
+	if (Status == STATUS_IMAGE_CERT_REVOKED) {
 		Log("[-] Your vulnerable driver list is enabled and have blocked the driver loading, you must disable vulnerable driver list to use kdmapper with intel driver" << std::endl);
 		Log("[-] Registry path to disable vulnerable driver list: HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\CI\\Config" << std::endl);
 		Log("[-] Set 'VulnerableDriverBlocklistEnable' as dword to 0" << std::endl);
 	}
-	else if (Status == 0xC0000022 || Status == 0xC000009A) { //STATUS_ACCESS_DENIED and STATUS_INSUFFICIENT_RESOURCES
+	else if (Status == STATUS_ACCESS_DENIED || Status == STATUS_INSUFFICIENT_RESOURCES) {
 		Log("[-] Access Denied or Insufficient Resources (0x" << std::hex << Status << "), Probably some anticheat or antivirus running blocking the load of vulnerable driver" << std::endl);
 	}
-	
-	
+
 	//Never should occur since kdmapper checks for "IsRunning" driver before
-	if (Status == 0xC000010E) {// STATUS_IMAGE_ALREADY_LOADED
+	if (Status == STATUS_IMAGE_ALREADY_LOADED) {
 		return true;
 	}
 	
@@ -104,7 +102,6 @@ bool service::StopAndRemove(const std::wstring& serviceName) {
 		status = RegDeleteTreeW(HKEY_LOCAL_MACHINE, servicesPath.c_str());
 		return false; //lets consider unload fail as error because can cause problems with anti cheats later
 	}
-	
 
 	status = RegDeleteTreeW(HKEY_LOCAL_MACHINE, servicesPath.c_str());
 	if (status != ERROR_SUCCESS) {

--- a/kdmapper/utils.cpp
+++ b/kdmapper/utils.cpp
@@ -49,7 +49,7 @@ uint64_t utils::GetKernelModuleAddress(const std::string& module_name) {
 
 	NTSTATUS status = NtQuerySystemInformation(static_cast<SYSTEM_INFORMATION_CLASS>(nt::SystemModuleInformation), buffer, buffer_size, &buffer_size);
 
-	while (status == nt::STATUS_INFO_LENGTH_MISMATCH) {
+	while (status == STATUS_INFO_LENGTH_MISMATCH) {
 		if (buffer != nullptr)
 			VirtualFree(buffer, 0, MEM_RELEASE);
 


### PR DESCRIPTION
- Replaced hardcoded NTSTATUS values with descriptive constants from <ntstatus.h>
- Added safe include for <ntstatus.h> with macro redefinition warning disabled
- Improved readability and maintainability by avoiding magic numbers