### PR TITLE
fixed g_HashCacheLockOffset check

### DIFF
--- a/kdmapper/intel_driver.cpp
+++ b/kdmapper/intel_driver.cpp
@@ -1142,7 +1142,7 @@ bool intel_driver::ClearKernelHashBucketList() {
 	}
 
 	auto g_HashCacheLockOffset = KDSymbolsHandler::GetInstance()->GetOffset(L"g_HashCacheLock");
-	if (!g_KernelHashBucketListOffset)
+	if (!g_HashCacheLockOffset)
 	{
 		kdmLog(L"[-] Can't Find g_HashCacheLock Offset" << std::endl);
 		return false;


### PR DESCRIPTION
previously the check was for g_KernelHashBucketListOffset but should have been for g_HashCacheLockOffset , this prevents kdmapper failing in case g_HasCacheLockOffset is null